### PR TITLE
custom separator

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -62,6 +62,8 @@ var historyCmd = &cobra.Command{
 		}
 		defer rows.Close()
 
+		var sep = viper.GetString("separator")
+
 		for rows.Next() {
 			var url string
 			var title string
@@ -73,7 +75,7 @@ var historyCmd = &cobra.Command{
 			}
 			var visitAt string
 			visitAt = time.Unix(unixTime, 0).String()
-			fmt.Println(visitAt + "|" + title + "|" + url + "|" + count)
+			fmt.Println(visitAt + sep + title + sep + url + sep + count)
 		}
 		err = rows.Err()
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,9 @@ func init() {
 	// when this action is called directly.
 	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	RootCmd.PersistentFlags().StringP("history_db_path", "", os.Getenv("HOME")+"/.config/google-chrome/Default/History", "History path for google chrome")
+	RootCmd.PersistentFlags().StringP("separator", "s", "|", "Separator for results")
 	viper.BindPFlag("history_db_path", RootCmd.PersistentFlags().Lookup("history_db_path"))
+	viper.BindPFlag("separator", RootCmd.PersistentFlags().Lookup("separator"))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
サイトのタイトルによく`|`が使われるのでオプションで変えられるようにしましたー。